### PR TITLE
[events] Add default event

### DIFF
--- a/src/main/kotlin/org/breizhcamp/kalon/application/dto/SetDefaultEventAPI.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/application/dto/SetDefaultEventAPI.kt
@@ -1,0 +1,9 @@
+package org.breizhcamp.kalon.application.dto
+
+import jakarta.validation.constraints.NotBlank
+import org.breizhcamp.kalon.domain.entities.EventId
+
+data class SetDefaultEventAPI(
+    @field:NotBlank
+    val defaultEventId: EventId,
+)

--- a/src/main/kotlin/org/breizhcamp/kalon/application/rest/AppConfigCtrl.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/application/rest/AppConfigCtrl.kt
@@ -1,0 +1,39 @@
+package org.breizhcamp.kalon.application.rest
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.breizhcamp.kalon.application.dto.EventFullAPI
+import org.breizhcamp.kalon.application.dto.SetDefaultEventAPI
+import org.breizhcamp.kalon.application.dto.toFullApi
+import org.breizhcamp.kalon.config.security.IsAdmin
+import org.breizhcamp.kalon.config.security.IsUser
+import org.breizhcamp.kalon.domain.use_cases.AppConfigCRUD
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/config", produces = ["application/json"])
+@Tag(name = "config", description = "Config related operations")
+class AppConfigCtrl(
+    private val appConfigCRUD: AppConfigCRUD,
+) {
+    @Operation(summary = "Get the default event")
+    @GetMapping("/default-event")
+    @IsUser
+    fun getDefaultEvent(): EventFullAPI =
+        appConfigCRUD.getDefaultEvent().toFullApi()
+
+    @Operation(summary = "Set the default event")
+    @PutMapping("/default-event")
+    @IsAdmin
+    fun setDefaultEvent(
+        @Valid
+        @RequestBody setDefaultEventAPI: SetDefaultEventAPI,
+    ) {
+        appConfigCRUD.setDefaultEvent(setDefaultEventAPI.defaultEventId)
+    }
+}

--- a/src/main/kotlin/org/breizhcamp/kalon/domain/entities/ModuleConfig.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/domain/entities/ModuleConfig.kt
@@ -10,6 +10,7 @@ data class OrgaModuleConfig(
 data class SponsorModuleConfig(
     val auth: ModuleAuthConfig,
     val backends: List<ModuleBackendConfig>,
+    val defaultEventId: EventId,
 ): ModuleConfig()
 
 data class ModuleAuthConfig (

--- a/src/main/kotlin/org/breizhcamp/kalon/domain/ports/AppConfigPort.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/domain/ports/AppConfigPort.kt
@@ -1,0 +1,7 @@
+package org.breizhcamp.kalon.domain.ports
+
+import org.breizhcamp.kalon.domain.entities.EventId
+
+interface AppConfigPort {
+    fun setDefaultEvent(eventId: EventId)
+}

--- a/src/main/kotlin/org/breizhcamp/kalon/domain/ports/EventPort.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/domain/ports/EventPort.kt
@@ -11,5 +11,6 @@ interface EventPort {
     fun delete(eventId: EventId)
     fun list(): List<Event>
     fun get(id: EventId): Event?
+    fun getDefaultEvent(): Event?
 
 }

--- a/src/main/kotlin/org/breizhcamp/kalon/domain/use_cases/AppConfigCRUD.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/domain/use_cases/AppConfigCRUD.kt
@@ -1,0 +1,28 @@
+package org.breizhcamp.kalon.domain.use_cases
+
+import org.breizhcamp.kalon.config.annotations.Tx
+import org.breizhcamp.kalon.config.annotations.UseCase
+import org.breizhcamp.kalon.domain.entities.Event
+import org.breizhcamp.kalon.domain.entities.EventId
+import org.breizhcamp.kalon.domain.exceptions.NotFoundException
+import org.breizhcamp.kalon.domain.ports.AppConfigPort
+import org.breizhcamp.kalon.domain.ports.EventPort
+
+@UseCase
+class AppConfigCRUD(
+    private val eventPort: EventPort,
+    private val appConfigPort: AppConfigPort,
+) {
+
+    fun getDefaultEvent(): Event =
+        eventPort.getDefaultEvent()
+            ?: throw NotFoundException("Default event not found")
+
+    @Tx
+    fun setDefaultEvent(eventId: EventId) {
+        if (!eventPort.isIdExists(eventId)) {
+            throw NotFoundException<Event>(eventId)
+        }
+        appConfigPort.setDefaultEvent(eventId)
+    }
+}

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/config/ModuleAdapter.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/config/ModuleAdapter.kt
@@ -11,10 +11,12 @@ import org.breizhcamp.kalon.domain.entities.ModuleConfig
 import org.breizhcamp.kalon.domain.entities.OrgaModuleConfig
 import org.breizhcamp.kalon.domain.entities.SponsorModuleConfig
 import org.breizhcamp.kalon.domain.ports.ModulePort
+import org.breizhcamp.kalon.infrastructure.db.repos.AppConfigRepo
 
 @Adapter
 class ModuleAdapter(
     private val config: KalonConfig,
+    private val appConfigRepo: AppConfigRepo,
 ): ModulePort {
 
     override fun getFromHost(host: String): ModuleConfig? {
@@ -28,6 +30,9 @@ class ModuleAdapter(
             "sponsor" -> SponsorModuleConfig(
                 auth = module.toAuthDomain(tenant),
                 backends = tenant.backends.map { it.toDomain() },
+                defaultEventId = requireNotNull(
+                    appConfigRepo.getDefaultEventId(),
+                ),
             )
             else -> null
         }

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/AppConfigAdapter.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/AppConfigAdapter.kt
@@ -1,0 +1,17 @@
+package org.breizhcamp.kalon.infrastructure.db
+
+import org.breizhcamp.kalon.config.annotations.Adapter
+import org.breizhcamp.kalon.domain.entities.EventId
+import org.breizhcamp.kalon.domain.ports.AppConfigPort
+import org.breizhcamp.kalon.infrastructure.db.repos.AppConfigRepo
+
+@Adapter
+class AppConfigAdapter(
+    private val appConfigRepo: AppConfigRepo,
+): AppConfigPort {
+    override fun setDefaultEvent(eventId: EventId) {
+        val appConfig = appConfigRepo.get()
+        appConfig.defaultEventId = eventId.value
+        appConfigRepo.save(appConfig)
+    }
+}

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/EventAdapter.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/EventAdapter.kt
@@ -33,4 +33,7 @@ class EventAdapter(
 
     override fun get(id: EventId): Event? =
         eventRepo.findByIdOrNull(id.value)?.toDomain()
+
+    override fun getDefaultEvent(): Event? =
+        eventRepo.getDefaultEvent()?.toDomain()
 }

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/model/AppConfigDB.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/model/AppConfigDB.kt
@@ -1,0 +1,13 @@
+package org.breizhcamp.kalon.infrastructure.db.model
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "app_config")
+class AppConfigDB(
+    @Id
+    val id: Int = 1,
+    var defaultEventId: String? = null,
+)

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/repos/AppConfigRepo.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/repos/AppConfigRepo.kt
@@ -1,0 +1,24 @@
+package org.breizhcamp.kalon.infrastructure.db.repos
+
+import org.breizhcamp.kalon.domain.entities.EventId
+import org.breizhcamp.kalon.infrastructure.db.model.AppConfigDB
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AppConfigRepo: JpaRepository<AppConfigDB, Int> {
+    @Query(
+        "SELECT app_config " +
+        "FROM AppConfigDB app_config " +
+        "WHERE app_config.id = 1",
+    )
+    fun get(): AppConfigDB
+
+    @Query(
+        "SELECT app_config.defaultEventId " +
+        "FROM AppConfigDB app_config " +
+        "WHERE app_config.id = 1",
+    )
+    fun getDefaultEventId(): EventId?
+}

--- a/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/repos/EventRepo.kt
+++ b/src/main/kotlin/org/breizhcamp/kalon/infrastructure/db/repos/EventRepo.kt
@@ -2,9 +2,18 @@ package org.breizhcamp.kalon.infrastructure.db.repos
 
 import org.breizhcamp.kalon.infrastructure.db.model.EventDB
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface EventRepo: JpaRepository<EventDB, String> {
     fun findAllByOrderByStartDateDesc(): List<EventDB>
+
+    @Query(
+        "SELECT event " +
+        "FROM EventDB event " +
+        "INNER JOIN AppConfigDB app_config " +
+        "ON app_config.defaultEventId = event.id",
+    )
+    fun getDefaultEvent(): EventDB?
 }

--- a/src/main/resources/db/changelog/db.changelog-2.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-2.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+		xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+		xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet id="002" author="floris">
+		<createTable tableName="app_config">
+			<column name="id" type="int" defaultValueNumeric="1">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="default_event_id" type="text">
+			<constraints nullable="true"/>
+			</column>
+		</createTable>
+		<addForeignKeyConstraint baseTableName="app_config"
+			baseColumnNames="default_event_id"
+			constraintName="fk_app_config_default_event"
+			referencedTableName="event"
+			referencedColumnNames="id"
+			onDelete="SET NULL"/>
+		<sql>
+			ALTER TABLE app_config
+			ADD CONSTRAINT app_config_single_row
+			CHECK (id = 1);
+		</sql>
+		<insert tableName="app_config">
+			<column name="id" valueNumeric="1"/>
+		</insert>
+	</changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
 	<include file="db/changelog/db.changelog-1.0.xml"/>
+	<include file="db/changelog/db.changelog-2.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a config system to Kalon that stores the default event id in the database. The default event id is exposed with some REST routes and in some module config.